### PR TITLE
fix(loader): yield each content part from multi-part extractors

### DIFF
--- a/src/mnemolet/cuore/ingestion/loader.py
+++ b/src/mnemolet/cuore/ingestion/loader.py
@@ -47,12 +47,12 @@ def stream_files(
 
                 if not file_added:
                     tracker.add_file(resolved_path, file_hash)
+                    file_added = True
 
-                data = {
+                yield {
                     "path": resolved_path,
                     "content": content_part,
                     "hash": file_hash,
                 }
-            yield data
-        except Exception as e:
-            print(f"Skipping {file_path}: {e}")
+        except Exception:
+            logger.exception("Skipping %s", file_path)


### PR DESCRIPTION
- Moved yield inside the for loop so every content_part from multi-part extractors (e.g. AudioExtractor) is streamed
- Added file_added = True to guard against duplicate DB writes
- Replaced print() with logger.exception() for proper traceback logging