### PR TITLE
fix(pdf-loader): correct slice bug that discarded most PDF text

### DIFF
--- a/src/mnemolet/cuore/ingestion/loaders/pdf_loader.py
+++ b/src/mnemolet/cuore/ingestion/loaders/pdf_loader.py
@@ -1,9 +1,10 @@
 from pathlib import Path
+from typing import Iterator
 
 from pypdf import PdfReader
 
 
-def extract_pdf(file: Path, chunk_size: int) -> str:
+def extract_pdf(file: Path, chunk_size: int) -> Iterator[str]:
     """
     Yield text chunks from a PDF.
 
@@ -27,7 +28,7 @@ def extract_pdf(file: Path, chunk_size: int) -> str:
 
         while len(text) >= chunk_size:
             yield text[:chunk_size]
-            text = text[chunk_size]
+            text = text[chunk_size:]
 
     if text:
         yield text


### PR DESCRIPTION
text[chunk_size] indexes a single character, discarding the rest of the buffer. text[chunk_size:] properly slices the remainder. Also fixed return type annotation from str to Iterator[str].