### PR TITLE
fix(text-extractor): add missing dot to .pl extension

### DIFF
--- a/src/mnemolet/cuore/ingestion/extractors/text_extractor.py
+++ b/src/mnemolet/cuore/ingestion/extractors/text_extractor.py
@@ -30,7 +30,7 @@ class TextExtractor(Extractor):
         ".ps1",
         ".rb",
         ".php",
-        "pl",
+        ".pl",
         # markdown
         # TODO: need additional work for csv and html
         ".md",


### PR DESCRIPTION
file.suffix always includes the leading dot, so 'pl' never matched and Perl .pl files were silently skipped.