### PR TITLE
fix(qdrant): use shared SentenceTransformer singleton instead of load…

### DIFF
--- a/src/mnemolet/cuore/embeddings/local_llm_embed.py
+++ b/src/mnemolet/cuore/embeddings/local_llm_embed.py
@@ -22,6 +22,11 @@ def _get_model() -> SentenceTransformer:
     return _model
 
 
+def get_model() -> SentenceTransformer:
+    """Return the shared SentenceTransformer singleton."""
+    return _get_model()
+
+
 def get_dimension() -> int:
     return _get_model().get_embedding_dimension()
 

--- a/src/mnemolet/cuore/query/retrieval/qdrant.py
+++ b/src/mnemolet/cuore/query/retrieval/qdrant.py
@@ -1,12 +1,13 @@
 from typing import Any
 
 from qdrant_client import QdrantClient
-from sentence_transformers import SentenceTransformer
+
+from mnemolet.cuore.embeddings.local_llm_embed import get_model
 
 
 class Qdrant:
     def __init__(self, qdrant_url: str, collection_name, model: str):
-        self.model = SentenceTransformer(model)
+        self.model = get_model()
         self.client = QdrantClient(qdrant_url)
         self.collection_name = collection_name
 


### PR DESCRIPTION
…ing a new copy

- Added public get_model() to local_llm_embed.py wrapping the private _get_model() singleton
- Replaced SentenceTransformer(model) in Qdrant class with get_model() to reuse the already-loaded model (~200MB savings per query)